### PR TITLE
Resolve relative PDB paths

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -656,7 +656,10 @@ fn find_pdbs(images: &[(OsString, u64, u64)]) -> Vec<(u64, u64, OsString, OwnedP
             Ok(x) => x,
             _ => continue,
         };
-        let pdb_path = PathBuf::from(pdb_path);
+        let mut pdb_path = PathBuf::from(pdb_path);
+        if pdb_path.is_relative() {
+            pdb_path = path.parent().unwrap().join(pdb_path);
+        }
         if pdb_path.exists() {
             let mut file = match std::fs::File::open(pdb_path) {
                 Err(_) => continue,


### PR DESCRIPTION
In some cases the PDB path returned from `pe_file.pdb_info()` is relative and includes only the filename of the PDB. This results in the existence check to fail:

https://github.com/nico-abram/blondie/blob/aefddb0f904a40afb465fe923dbcfbc3407b7ab2/src/lib.rs#L659-L660

We can check if the path is relative and join it with the path of the image in that case.

Fixes #65 
Fixes flamegraph-rs/flamegraph#277