### PR TITLE
Add the ability to trace processes by process ID

### DIFF
--- a/src/blondie_bin.rs
+++ b/src/blondie_bin.rs
@@ -78,6 +78,9 @@ fn main() -> Result<(), blondie::Error> {
                 std::fs::write(trace_file, &trace_output).unwrap();
             }
 
+            println!("Wrote dtrace output to {:?}",trace_file);
+            
+
             let mut collapsed_output = Vec::new();
             let collapse_options = inferno::collapse::dtrace::Options::default();
             inferno::collapse::dtrace::Folder::from(collapse_options)

--- a/src/blondie_bin.rs
+++ b/src/blondie_bin.rs
@@ -78,9 +78,6 @@ fn main() -> Result<(), blondie::Error> {
                 std::fs::write(trace_file, &trace_output).unwrap();
             }
 
-            println!("Wrote dtrace output to {:?}",trace_file);
-            
-
             let mut collapsed_output = Vec::new();
             let collapse_options = inferno::collapse::dtrace::Options::default();
             inferno::collapse::dtrace::Folder::from(collapse_options)


### PR DESCRIPTION
Hello!  I've been looking for a solution to doing something approximating "in-process" profiling in Rust on Windows, and Blondie being able to programmatically initiate ETW traces and generate DTrace output and flamegraphs is fantastic!  Thank you for writing it.  Hopefully I'm not being too presumptuous in sending this PR through, I've been using blondie extensively and have made some additions.

First up, this is my first ever Rust PR so I'm not super familiar with the etiquette and/or conventions, so please bear with me if I'm out of line with anything

## Justification
For my use-case (and probably other folks as well), I initiate the code I want to flamegraph via the "criterion" benchmark harness, and run a suite of benchmarks.  However, understandably, I only want to profile the stuff that is not part of the benchmark setup suite.  This PR allows a user to hook blondie into arbitrary processes by ID - in my case, it's for criterion's custom profiler hook to automagically generate flamegraphs for the algorithms/functions I want to test, all without calling out to an external process like dtrace or perfview or whatever.

## Implementation
The implementation is pretty simple and relatively non-intrusive - basically I changed the main `trace_from_process_id` function to accept a PID as its parameter by default rather than a std::process::Child.  Then, inside that function we resolve the process handle using Win32 `OpenProcess` (wrapped by `handle_from_process_id`) rather than using `clone_handle`.  To support waiting for the process to end, we use the new function `wait_for_process_by_handle` (wrapping `WaitForSingleObject`) rather than `process.wait()`.  This allows us to trace in all three scenarios: `trace_command`, `trace_child` and now, `trace_pid`.

I also did some minor cleanup, fixing cargo doc, cargo clippy, and running cargo format.

Everything seems to work from my end, but I assume you have your own test scenarios, so please let me know if I messed something up.  One thing to note - I get a weird unwrap error when running this under the 'debug' profile rather than 'release', but that happens without my changes as well, so I hope that's unrelated!

## Further work
I'd like to include a harness to directly support criterion's custom profiler as a feature, much like pprof-rs has done (see https://github.com/tikv/pprof-rs and https://github.com/tikv/pprof-rs/blob/master/src/criterion.rs) - if you're okay with that then I will send another PR through.